### PR TITLE
Fix feed link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -17,7 +17,7 @@
       <a class="sidebar-nav-item" href="http://eepurl.com/bbuvuz">Subscribe to Mailing List</a>
       <a class="sidebar-nav-item" href="https://twitter.com/schneems">@schneems</a>
       <a class="sidebar-nav-item" href="https://github.com/schneems">GitHub</a>
-      <a class="sidebar-nav-item" href="feed.xml">RSS</a>
+      <a class="sidebar-nav-item" href="/feed.xml">RSS</a>
 
       {% assign pages_list = site.pages %}
       {% for node in pages_list %}


### PR DESCRIPTION
If you are on any blog post or anything but root it will open incorrectly. For example clicking the link on http://www.schneems.com/2016/01/25/ruby-debugging-magic-cheat-sheet.html will take you to http://www.schneems.com/2016/01/25/feed.xml