### PR TITLE
Fix wrong width in Firefox

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -361,7 +361,7 @@ pre {
 
 .content {
   padding: 2rem;
-  flex: 2;
+  flex: 2 1 auto;
 }
 
 @media (min-width: 48em) {


### PR DESCRIPTION
As mention in a lobster's comment : https://lobste.rs/s/ehc9li/how_i_reduced_my_db_server_load_by_80#c_3tknvn

Articles are not properly displayed on Firefox. Article's width go outside the screen: 
<img width="1280" alt="capture d ecran 2017-07-19 a 09 28 06" src="https://user-images.githubusercontent.com/8417720/28355938-678c26ac-6c66-11e7-85ae-d3b158ae61bd.png">

I'm very bad at CSS but it seems this change fix the issue: 

<img width="1280" alt="capture d ecran 2017-07-19 a 09 27 43" src="https://user-images.githubusercontent.com/8417720/28355961-825b567e-6c66-11e7-9c2f-8e6f4942c773.png">

Thanks for all the very good blogposts. 
