### PR TITLE
Use correct <length> CSS syntax as otherwise it’s ignored

### DIFF
--- a/assets/stylesheets/application.css
+++ b/assets/stylesheets/application.css
@@ -272,7 +272,7 @@ tbody tr:nth-child(odd) th {
 }
 
 .page, .post, .posts {
-  max-width: 40 rem;
+  max-width: 40rem;
 }
 
 /* Blog post or page title */


### PR DESCRIPTION
Due to the invalid syntax this value is ignored entirely, tested in Chrome & Firefox.

From MDN:

> there is no space between the unit literal and the number