### PR TITLE
Use full content for RSS

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -10,7 +10,7 @@
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.excerpt | xml_escape }}</description>
+        <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
         <link>{{ site.BASE_PATH_FOR_RSS }}{{ post.url }}</link>
         <guid isPermaLink="true">{{ site.BASE_PATH_FOR_RSS }}{{ post.url }}</guid>


### PR DESCRIPTION
Rather than only including an excerpt, add the full content of the
article into the RSS feed so that readers can consume the articles in
their preferred format, either in their feed reader or, if they wish,
clicking on the link to show the article in its original context.

The potential downside of this is that your perceived readership may
decrease as RSS reads will not be included in Google Analytics. The
upside of that is that fewer people are being tracked by Google
Analytics. Also, most of your readership probably have GA blocked and
I'd bet you a dollar that the percentage who use RSS _and_ have GA
blocked is even higher.